### PR TITLE
fix: remove symlinks from build output

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,6 +51,8 @@ jobs:
         run: python -m pip install -Uq -e .
       - name: Build HTML pages with Sphinx
         run: sphinx-build --builder html --fail-on-warning --fresh-env --write-all $SOURCE_DIR $BUILD_DIR
+      - name: Remove symlinks from build output
+        run: find $BUILD_DIR -type l -delete
       - name: Upload built documentation as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
add step to remove symlinks from build output in CI. related to #39 #38 #36 #35 