### PR TITLE
build: run only for some files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
       - "requirements.txt"
       - "pyproject.toml"
   pull_request:
+    paths:
+      - "docs/**"
+      - "theme/**"
+      - "requirements.txt"
+      - "pyproject.toml"
 
 env:
   BUILD_DIR: docs/build/


### PR DESCRIPTION
this resolves the issue for unnecessary CI runs for PRs for un-required files. this also tests #31 