### PR TITLE
feat(thumbnail): add directive for embedding video

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,7 @@ deps = [
   "types-beautifulsoup4",
   "types-docutils",
   "typing_extensions",
+  "types-requests",
 ]
 commands = [
   [ "mypy", "theme", "--config-file", "pyproject.toml", "--color-output", "--show-error-codes" ],

--- a/theme/base/static/smart.css
+++ b/theme/base/static/smart.css
@@ -389,6 +389,15 @@ samp {
         border-bottom-right-radius: 0.5rem
     }
 
+    .sd-row-cols-2>*,
+    .sd-row-cols-3>* {
+        width: 100% !important
+    }
+
+    details.sd-dropdown .sd-summary-icon {
+        display: none !important
+    }
+
     .picture-figure.align-left,
     .picture-figure.align-right {
         float: none;
@@ -1434,4 +1443,79 @@ li .badge {
 
 .scbs-carousel-control-next-icon::before {
     content: "\f061"
+}
+
+.youtube-card-container {
+    text-decoration: none;
+    color: inherit;
+    display: inline-block;
+    width: 100%
+}
+
+#content .youtube-card-container {
+    text-decoration: none !important
+}
+
+.youtube-card {
+    display: flex;
+    flex-direction: column
+}
+
+.youtube-card-container:hover img {
+    transform: scale(1.02)
+}
+
+.youtube-thumbnail-wrapper {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    padding-top: 56.25%
+}
+
+.youtube-thumbnail-wrapper img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    margin: 0 !important;
+    border-radius: 0 !important
+}
+
+.youtube-card .sd-card-text {
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin: 1rem auto !important;
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+.youtube-card-content {
+    padding: 0
+}
+
+.youtube-title {
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin: 1rem 1rem 0.4rem 0 !important;
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+.youtube-channel {
+    color: hsl(var(--muted-foreground));
+    font-size: .875rem;
+    line-height: 1.25rem;
+    margin: 0 1rem 1.25rem 0 !important
 }

--- a/theme/base/static/smart.js
+++ b/theme/base/static/smart.js
@@ -264,6 +264,7 @@ $(window).scroll(function () {
             if (currentHeading) {
                 currentHeading.link.classList.add('toc-active');
                 currentHeading.link.style.color = 'hsl(var(--foreground))';
+                currentHeading.link.style.fontWeight = '500';
             }
         }
         let ticking = false;

--- a/theme/base/static/sphinx-design.css
+++ b/theme/base/static/sphinx-design.css
@@ -7,6 +7,11 @@
     --sd-color-tabs-underline: hsl(var(--border))
 }
 
+.sd-row {
+    --sd-gutter-x: 0.75rem;
+    --sd-gutter-y: 1rem
+}
+
 .sd-card {
     background-color: hsl(var(--card));
     border-color: hsl(var(--border));
@@ -19,6 +24,10 @@
 .sd-card-body:hover {
     box-shadow: var(--box-shadow);
     border-radius: var(--radius)
+}
+
+.sd-dropdown .sd-card-body:hover {
+    box-shadow: none
 }
 
 .sd-sphinx-override p {
@@ -38,6 +47,14 @@
 .sd-summary-title {
     color: hsl(var(--muted-foreground));
     font-weight: 500 !important
+}
+
+details.sd-dropdown summary.sd-summary-title svg {
+    opacity: 1 !important;
+    margin-right: 0;
+    margin-bottom: 0;
+    height: auto;
+    width: auto
 }
 
 .sd-card-footer,
@@ -81,8 +98,6 @@ details.sd-dropdown summary.sd-summary-title {
     padding: 0;
     text-transform: none;
     color: hsl(var(--foreground));
-    font-size: 1.5rem;
-    font-weight: 600;
     line-height: 1.625rem;
     letter-spacing: -0.4px
 }
@@ -114,7 +129,6 @@ div.sd-summary-content.sd-card-body {
     margin-bottom: -0.125rem;
     margin-right: .25rem
 }
-
 
 nav a svg .fas,
 nav a svg .sd-octicon,

--- a/theme/base/thumbnail.html.jinja
+++ b/theme/base/thumbnail.html.jinja
@@ -1,0 +1,21 @@
+<!--
+SMART Sphinx Theme YouTube Thumbnail Template
+=============================================
+
+Author: Akshay Mestry <xa@mes3.dev>
+Created on: Saturday, 6 September 2025
+Last updated on: Sunday, 7 September 2025
+-->
+{% block youtube_thumbnail %}
+<a href="{{ src }}" target="_blank" rel="noopener noreferrer" class="youtube-card-container">
+  <div class="youtube-card">
+    <div class="youtube-thumbnail-wrapper">
+      <img src="{{ thumbnail }}" alt="Watch {{ title }} on YouTube" loading="lazy">
+    </div>
+    <div class="youtube-card-content">
+      <p class="youtube-title">{{ title }}</p>
+      <p class="youtube-channel">{{ channel|d("Watch on YouTube") }}</p>
+    </div>
+  </div>
+</a>
+{% endblock youtube_thumbnail %}

--- a/theme/internal/__init__.py
+++ b/theme/internal/__init__.py
@@ -4,7 +4,7 @@ SMART Sphinx Theme Extension Manager
 
 Author: Akshay Mestry <xa@mes3.dev>
 Created on: Saturday, 22 February 2025
-Last updated on: Tuesday, 2 September 2025
+Last updated on: Saturday, 6 September 2025
 
 This module manages SMART Sphinx Theme's custom directive and roles.
 """
@@ -16,6 +16,7 @@ import typing as t
 from . import author
 from . import picture
 from . import tagged
+from . import thumbnail
 from . import video
 from . import youtube
 
@@ -27,6 +28,7 @@ directives: t.Sequence[types.ModuleType] = (
     author,
     picture,
     tagged,
+    thumbnail,
     video,
     youtube,
 )

--- a/theme/internal/thumbnail.py
+++ b/theme/internal/thumbnail.py
@@ -1,0 +1,141 @@
+"""\
+SMART Sphinx Theme YouTube Thumbnail Directive
+==============================================
+
+Author: Akshay Mestry <xa@mes3.dev>
+Created on: Saturday, 6 September 2025
+Last updated on: Sunday, 7 September 2025
+
+This module defines a custom `thumbnail` directive for the SMART Sphinx
+Theme. The directive allows authors to embed a YouTube video thumbnail
+card directly within their documentation.
+
+The `thumbnail` directive is designed to extend reStructuredText (rST)
+capabilities by fetching metadata from a YouTube URL and rendering a
+styled card.
+
+The `thumbnail` directive can be used in reStructuredText documents as
+follows::
+
+    .. thumbnail:: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+        :title: Never Gonna Give You Up
+        :channel: Rick Astley
+
+The above snippet will be processed and rendered according to the
+theme's Jinja2 template, producing a consistent thumbnail card in the
+final HTML output.
+
+.. note::
+
+    This directive is exclusive to the SMART Sphinx Theme. If you
+    switch to a different theme, the behavior or availability of this
+    directive may change. Please refer to the specific theme's
+    documentation for further information.
+"""
+
+from __future__ import annotations
+
+import os.path as p
+import typing as t
+
+import docutils.nodes as nodes
+import docutils.parsers.rst as rst
+import jinja2
+import requests
+from bs4 import BeautifulSoup as Soup
+
+
+if t.TYPE_CHECKING:
+    from sphinx.writers.html import HTMLTranslator
+
+name: t.Final[str] = "thumbnail"
+here: str = p.dirname(__file__)
+html = p.join(p.abspath(p.join(here, "../base")), "thumbnail.html.jinja")
+
+with open(html) as f:
+    template = jinja2.Template(f.read())
+
+
+class node(nodes.Element):
+    """Class to represent a custom node in the document tree.
+
+    This class extends the `nodes.Element` from `docutils`, serving as
+    the container for the parsed information. The node will
+    ultimately be transformed into HTML or other output formats by the
+    relevant Sphinx translators.
+    """
+
+
+class directive(rst.Directive):
+    """Custom `thumbnail` directive for reStructuredText.
+
+    This class defines the behavior of the `thumbnail` directive,
+    including how it processes arguments and options, fetches video
+    metadata, and generates nodes to be inserted into the document tree.
+    """
+
+    has_content = True
+    option_spec = {  # noqa: RUF012
+        "title": rst.directives.unchanged,
+        "channel": rst.directives.unchanged,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        """Parse the directive content, fetch metadata, and create a
+        node tree.
+
+        This method processes the YouTube URL from the directive's
+        content, fetches metadata, and constructs a `thumbnail.node`
+        containing parsed `docutils` nodes for the title and caption.
+        This allows Sphinx to render them correctly.
+
+        :return: A list containing a single `thumbnail.node` element.
+        """
+        self.assert_has_content()
+        src = rst.directives.uri(self.content.pop())
+        vid = src
+        if "youtu.be/" in src:
+            vid = src.rsplit("/", 1)[-1].split("?", 1)[0]
+        elif "watch?v=" in src:
+            vid = src.split("v=", 1)[-1].split("&", 1)[0]
+        if "title" not in self.options:
+            soup = Soup(requests.get(src, timeout=1).text, "html.parser")
+            self.options["title"] = soup.find("title").text
+        self.options["src"] = src
+        self.options["thumbnail"] = (
+            f"https://img.youtube.com/vi/{vid}/hqdefault.jpg"
+        )
+        attributes: dict[str, str] = {}
+        attributes["text"] = template.render(**self.options)
+        attributes["format"] = "html"
+        return [nodes.raw(**attributes)]
+
+
+def visit(self: HTMLTranslator, node: node) -> None:
+    """Handle the entry processing of the `thumbnail` node during HTML
+    generation.
+
+    This method is called when the HTML translator encounters the
+    `thumbnail` node in the document tree. It retrieves the relevant
+    attributes from the node (like title and channel) and uses Jinja2
+    templating to produce the final HTML output. Since the `thumbnail`
+    node does not require any actions, the method currently acts as a
+    placeholder.
+
+    :param self: The HTML translator instance.
+    :param node: The `thumbnail` node being processed.
+    """
+
+
+def depart(self: HTMLTranslator, node: node) -> None:
+    """Handle the exit processing of the `thumbnail` node during HTML
+    generation.
+
+    This method is invoked after the node's HTML representation has been
+    fully processed and added to the output. Since the `thumbnail` node
+    does not require any closing actions, the method currently acts as a
+    placeholder.
+
+    :param self: The HTML translator instance.
+    :param node: The `thumbnail` node being processed.
+    """


### PR DESCRIPTION
This commit introduces a new thumbnail directive to enhance the presentation of YouTube video links within the documentation. The thumbnail directive allows for embedding video thumbnails with title and channel information, providing a more visually appealing and informative way to link to videos.

Related to #65, #67