### PR TITLE
style: show sponsor button only on left sidebar

### DIFF
--- a/theme/base/sidebar_toc.html.jinja
+++ b/theme/base/sidebar_toc.html.jinja
@@ -13,4 +13,4 @@ Last updated on: Sunday, 7 September 2025
   {{ toctree(titles_only=true, collapse=false) }}
   {%- endif %}
 </nav>
-<a href="{{ sponsor|d('#') }}" target="_blank" rel="noopener noreferrer" class="sidebar-github-button"><i class="fa-regular fa-heart sd-text-danger"></i>Sponsor on GitHub</a>
+<a href="{{ sponsor|d('#') }}" target="_blank" rel="noopener noreferrer" class="sidebar-button"><i class="fa-regular fa-heart sd-text-danger"></i>Sponsor on GitHub</a>

--- a/theme/base/static/smart.css
+++ b/theme/base/static/smart.css
@@ -410,13 +410,6 @@ samp {
         margin: 1rem auto
     }
 
-    #left-sidebar .sidebar-github-button {
-        display: inline-flex;
-    }
-
-    #right-sidebar .sidebar-github-button {
-        display: none !important;
-    }
 }
 
 /* iPad view */
@@ -464,13 +457,6 @@ samp {
         width: 768px
     }
 
-    .sidebar-github-button {
-        display: none !important;
-    }
-
-    #right-sidebar .sidebar-github-button {
-        display: inline-flex !important;
-    }
 }
 
 #content h1 {
@@ -1532,26 +1518,19 @@ li .badge {
     margin: 0 1rem 1.25rem 0 !important
 }
 
-.sidebar-github-button {
-    display: inline-flex;
-    align-items: center;
+.sidebar-button {
     justify-content: center;
     gap: 0.5rem;
     border-radius: calc(var(--radius) / 1.5);
     height: 2rem;
-    padding: 0 0.5rem;
+    padding: 0 0.5rem !important;
     font-size: 0.8rem;
-    color: hsl(var(--muted-foreground));
+    color: hsl(var(--foreground)) !important;
     background-color: hsl(var(--light-accent));
-    border: 1px solid hsl(var(--border)) !important;
-    transition: background-color var(--duration-normal) var(--ease-in-out), color var(--duration-normal) var(--ease-in-out), box-shadow var(--duration-normal) var(--ease-in-out), transform var(--duration-normal) var(--ease-in-out);
+    border: 1px solid hsl(var(--border)) !important
 }
 
-.sidebar-github-button:hover {
-    color: hsl(var(--foreground))
-}
-
-.sidebar-github-button:hover .fa-heart {
+.sidebar-button:hover .fa-heart {
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;
     font: var(--fa-font-solid)

--- a/theme/base/toc.html.jinja
+++ b/theme/base/toc.html.jinja
@@ -12,7 +12,5 @@ Last updated on: Sunday, 7 September 2025
   <p class="font-medium">On this page</p>
   {{ toc }}
   {% endif %}
-  {%- block toc_after %}
-    <a href="{{ sponsor|d('#') }}" target="_blank" rel="noopener noreferrer" class="sidebar-github-button"><i class="fa-regular fa-heart sd-text-danger"></i>Sponsor on GitHub</a>
-  {%- endblock -%}
+  {%- block toc_after %}{%- endblock -%}
 </aside>


### PR DESCRIPTION
this PR in a way reverts the newly merged PR #71 by just keeping the sponsor button on the left sidebar as it looked more appropriate the more I experimented.